### PR TITLE
add compilation example support to ch02-*

### DIFF
--- a/src/ch02-01.more_types.md
+++ b/src/ch02-01.more_types.md
@@ -118,7 +118,8 @@ Token::Name(name) => {
 
 ```rust, ignore
 fn add_const(constants: &mut Vec<Value>, c: Value) -> usize {
-    constants.push(c)
+    constants.push(c);
+    constants.len() - 1
 }
 
 fn load_const(constants: &mut Vec<Value>, dst: usize, c: Value) -> ByteCode {

--- a/translations/en/ch02-01.more_types.md
+++ b/translations/en/ch02-01.more_types.md
@@ -118,7 +118,7 @@ The main code has been introduced. The definition of the function `load_const()`
 
 ```rust, ignore
 fn add_const(constants: &mut Vec<Value>, c: Value) -> usize {
-     constants. push(c)
+     constants. push(c);
      constants. len() - 1
 }
 

--- a/translations/en/ch02-01.more_types.md
+++ b/translations/en/ch02-01.more_types.md
@@ -119,6 +119,7 @@ The main code has been introduced. The definition of the function `load_const()`
 ```rust, ignore
 fn add_const(constants: &mut Vec<Value>, c: Value) -> usize {
      constants. push(c)
+     constants. len() - 1
 }
 
 fn load_const(constants: &mut Vec<Value>, dst: usize, c: Value) -> ByteCode {

--- a/translations/en/ch02-03.assignment.md
+++ b/translations/en/ch02-03.assignment.md
@@ -122,6 +122,14 @@ Then look at the `assignment()` function:
 
 For the case where the lvalue is a local variable, call `load_exp()` to handle it. For the case of global variables, according to the type of the expression on the right, generate `SetGlobalConst`, `SetGlobal` and `SetGlobalGlobal` bytecodes respectively.
 
+Finally, the `get_local()` definition:
+
+```rust, ignore
+    fn get_local(&self, name: &str) -> Option<usize> {
+        self.locals.iter().rposition(|v| v == name)
+    }
+```
+
 ## Test
 
 Use the following code to test the above six variable assignments:


### PR DESCRIPTION
as I do not speak chinese and translators tender to make big mistakes, the chinese version of the second commit (2-3 change) was not made to src.

the key-point of the changes are that, following strictly the tutorial it is not possible to compile the code at the changed points to run the examples, at least not without looking at the original source code (this rule is valid for 2-3 change only, 2-1 change is not present at source). ;)